### PR TITLE
Add Emacs 26 support.

### DIFF
--- a/config.el
+++ b/config.el
@@ -10,6 +10,3 @@
 ;;; License: GPLv3
 
 ;; Variables
-
-;; TODO fix this for spacemacs26
-;;(spacemacs|defvar-company-backends irony-mode)

--- a/config.el
+++ b/config.el
@@ -11,5 +11,5 @@
 
 ;; Variables
 
-(spacemacs|defvar-company-backends irony-mode)
-(spacemacs|defvar-company-backends irony-mode)
+;; TODO fix this for spacemacs26
+;;(spacemacs|defvar-company-backends irony-mode)

--- a/packages.el
+++ b/packages.el
@@ -32,22 +32,17 @@
                 (irony-cdb-autosetup-compile-options)))
     ))
 
-;; TODO setup irony for emacs26
-;; (defun platformio/init-company-irony ()
-;;   (use-package company-irony
-;;     :defer t
-;;     :init
-;;     (push 'company-irony company-backends-irony-mode)))
+(defun platformio/init-company-irony ()
+  (use-package company-irony
+    :defer t
+    :config
+    (add-to-list 'company-backends 'company-irony)))
 
 (defun platformio/init-irony-eldoc ()
   (use-package irony-eldoc
     :defer t
     :init
     (add-hook 'irony-mode-hook 'irony-eldoc)))
-
-;; TODO setup company for emacs26
-;; (defun platformio/post-init-company ()
-;;   (spacemacs|add-company-hook irony-mode))
 
 (defun platformio/init-platformio-mode ()
   (use-package platformio-mode

--- a/packages.el
+++ b/packages.el
@@ -32,11 +32,12 @@
                 (irony-cdb-autosetup-compile-options)))
     ))
 
-(defun platformio/init-company-irony ()
-  (use-package company-irony
-    :defer t
-    :init
-    (push 'company-irony company-backends-irony-mode)))
+;; TODO setup irony for emacs26
+;; (defun platformio/init-company-irony ()
+;;   (use-package company-irony
+;;     :defer t
+;;     :init
+;;     (push 'company-irony company-backends-irony-mode)))
 
 (defun platformio/init-irony-eldoc ()
   (use-package irony-eldoc
@@ -44,8 +45,9 @@
     :init
     (add-hook 'irony-mode-hook 'irony-eldoc)))
 
-(defun platformio/post-init-company ()
-  (spacemacs|add-company-hook irony-mode))
+;; TODO setup company for emacs26
+;; (defun platformio/post-init-company ()
+;;   (spacemacs|add-company-hook irony-mode))
 
 (defun platformio/init-platformio-mode ()
   (use-package platformio-mode

--- a/packages.el
+++ b/packages.el
@@ -13,7 +13,7 @@
   '(
     company
     irony
-    company-irony
+    (company-irony :toggle (configuration-layer/package-used-p 'company))
     irony-eldoc
     platformio-mode
     ))
@@ -35,8 +35,10 @@
 (defun platformio/init-company-irony ()
   (use-package company-irony
     :defer t
-    :config
-    (add-to-list 'company-backends 'company-irony)))
+    :init
+    (spacemacs|add-company-backends
+       :backends company-irony
+       :modes irony-mode)))
 
 (defun platformio/init-irony-eldoc ()
   (use-package irony-eldoc

--- a/packages.el
+++ b/packages.el
@@ -11,7 +11,6 @@
 
 (defconst platformio-packages
   '(
-    company
     irony
     (company-irony :toggle (configuration-layer/package-used-p 'company))
     irony-eldoc


### PR DESCRIPTION
Spacemac's autocompletion code was moved to the autocompletion layer.

Completion does not work for me, but I am new to *emacs.

Compile and Upload shortcuts still work.